### PR TITLE
Don't reverse the list just merge in rev order

### DIFF
--- a/dataklasses.py
+++ b/dataklasses.py
@@ -34,7 +34,7 @@ def codegen(func):
     return decorate
 
 def all_hints(cls):
-    return reduce(lambda x, y: x | getattr(y, '__annotations__',{}), reversed(cls.__mro__), {})
+    return reduce(lambda x, y: getattr(y, '__annotations__',{}) | x, cls.__mro__, {})
 
 @codegen
 def make__init__(fields):


### PR DESCRIPTION
The use of `reversed` ensures that derived classes' attributes override those of base classes. Don't need to do this, just apply the operator to the reversed pair of arguments. The initial case where x is `{}` will still work the same.