### PR TITLE
Make `__match_args__` a tuple (not a dict)

### DIFF
--- a/dataklasses.py
+++ b/dataklasses.py
@@ -75,7 +75,7 @@ def dataklass(cls):
     if not '__eq__' in clsdict: cls.__eq__ = make__eq__(fields)
     # if not '__iter__' in clsdict:  cls.__iter__ = make__iter__(fields)
     # if not '__hash__' in clsdict:  cls.__hash__ = make__hash__(fields)
-    cls.__match_args__ = fields
+    cls.__match_args__ = tuple(fields)
     return cls
 
 # Example use


### PR DESCRIPTION
```py
Python 3.10.0 (default, Dec 10 2021, 15:03:21) [GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from dataklasses import dataklass
>>> @dataklass
... class Point:
...     x: int
...     y: int
... 
>>> match Point(0, 0):
...     case Point(x, y):
...         pass
... 
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
TypeError: Point.__match_args__ must be a tuple (got dict)
```